### PR TITLE
Add a magic word in front of the header

### DIFF
--- a/header.go
+++ b/header.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	extensionTypeSelectiveAck = 1
+	syncthingUTPMagic         = uint32(0x83840001)
 )
 
 type extensionField struct {
@@ -54,6 +55,12 @@ func unmarshalExtensions(_type byte, b []byte) (n int, ef []extensionField, err 
 var errInvalidHeader = errors.New("invalid header")
 
 func (h *header) Unmarshal(b []byte) (n int, err error) {
+	magic := binary.BigEndian.Uint32(b)
+	if magic != syncthingUTPMagic {
+		err = errInvalidHeader
+		return
+	}
+	b = b[4:]
 	h.Type = st(b[0] >> 4)
 	h.Version = int(b[0] & 0xf)
 	if h.Type > stMax || h.Version != 1 {
@@ -70,20 +77,21 @@ func (h *header) Unmarshal(b []byte) (n int, err error) {
 	h.WndSize = binary.BigEndian.Uint32(b[12:16])
 	h.SeqNr = binary.BigEndian.Uint16(b[16:18])
 	h.AckNr = binary.BigEndian.Uint16(b[18:20])
-	n += 20
+	n += 24
 	return
 }
 
 func (h *header) Marshal() (ret []byte) {
-	hLen := 20 + func() (ret int) {
+	hLen := 4 + 20 + func() (ret int) {
 		for _, ext := range h.Extensions {
 			ret += 2 + len(ext.Bytes)
 		}
 		return
 	}()
 	ret = sendBufferPool.Get().([]byte)[:hLen:minMTU]
+	binary.BigEndian.PutUint32(ret, syncthingUTPMagic)
 	// ret = make([]byte, hLen, minMTU)
-	p := ret // Used for manipulating ret.
+	p := ret[4:] // Used for manipulating ret.
 	p[0] = byte(h.Type<<4 | 1)
 	binary.BigEndian.PutUint16(p[2:4], h.ConnID)
 	binary.BigEndian.PutUint32(p[4:8], h.Timestamp)

--- a/utp.go
+++ b/utp.go
@@ -35,7 +35,7 @@ const (
 	recvWindow = 1 << 18 // 256KiB
 	// uTP header of 20, +2 for the next extension, and 8 bytes of selective
 	// ACK.
-	maxHeaderSize  = 30
+	maxHeaderSize  = 34
 	maxPayloadSize = minMTU - maxHeaderSize
 	maxRecvSize    = 0x2000
 


### PR DESCRIPTION
This identifies the connection as a Syncthing connection, makes it look
less like uTP for interested viewers. Passes the test suite here, and
works when copied into our vendoring directory.