### PR TITLE
Add CloseNow() to utp.Socket

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -510,6 +510,13 @@ func (c *Conn) destroy(reason error) {
 	c.detach()
 }
 
+func (c *Conn) closeNow() (err error) {
+	c.closed.Set()
+	c.writeFin()
+	c.destroy(errors.New("destroyed"))
+	return
+}
+
 func (c *Conn) Close() (err error) {
 	mu.Lock()
 	defer mu.Unlock()


### PR DESCRIPTION
@anacrolix 

This change adds the method `CloseNow()` to `utp.Socket`. This method attempts to block until Go has completely destroyed the underlying socket. Go has a [mutex](https://github.com/golang/go/blob/master/src/net/fd_mutex.go) around the file descriptor under the hood so we must wait until the PacketConn has returned from all reads and writes.

This method should help to avoid "bind: address already in use" errors that can occur from lazily destroying the socket with `Close()` followed by recreating it on the same address as mentioned in #15.