### PR TITLE
Use real address of remote host.

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -349,11 +349,11 @@ func (s *Socket) DialTimeout(addr string, timeout time.Duration) (nc net.Conn, e
 	c.recv_id = s.newConnID(resolvedAddrStr(c.RemoteAddr().String()))
 	c.send_id = c.recv_id + 1
 	if logLevel >= 1 {
-		log.Printf("dial registering addr: %s", netAddr.String())
+		log.Printf("dial registering addr: %s", c.RemoteAddr().String())
 	}
 	if !s.registerConn(c.recv_id, resolvedAddrStr(c.RemoteAddr().String()), c) {
 		err = errors.New("couldn't register new connection")
-		log.Println(c.recv_id, netAddr.String())
+		log.Println(c.recv_id, c.RemoteAddr().String())
 		for k, c := range s.conns {
 			log.Println(k, c, c.age())
 		}

--- a/socket.go
+++ b/socket.go
@@ -296,6 +296,20 @@ func (s *Socket) newConnID(remoteAddr resolvedAddrStr) (id uint16) {
 }
 
 func (s *Socket) newConn(addr net.Addr) (c *Conn) {
+	udpAddr, ok := addr.(*net.UDPAddr)
+	if ok {
+		// find the real address that will be used.
+		l, err := net.DialUDP("udp", nil, udpAddr)
+		if err != nil {
+			panic(err)
+		}
+		if logLevel >= 1 {
+			log.Printf("updating addr from %v to %v\n", addr, l.RemoteAddr())
+		}
+		addr = l.RemoteAddr()
+		l.Close()
+	}
+
 	c = &Conn{
 		socket:           s,
 		remoteSocketAddr: addr,
@@ -332,12 +346,12 @@ func (s *Socket) DialTimeout(addr string, timeout time.Duration) (nc net.Conn, e
 
 	mu.Lock()
 	c := s.newConn(netAddr)
-	c.recv_id = s.newConnID(resolvedAddrStr(netAddr.String()))
+	c.recv_id = s.newConnID(resolvedAddrStr(c.RemoteAddr().String()))
 	c.send_id = c.recv_id + 1
 	if logLevel >= 1 {
 		log.Printf("dial registering addr: %s", netAddr.String())
 	}
-	if !s.registerConn(c.recv_id, resolvedAddrStr(netAddr.String()), c) {
+	if !s.registerConn(c.recv_id, resolvedAddrStr(c.RemoteAddr().String()), c) {
 		err = errors.New("couldn't register new connection")
 		log.Println(c.recv_id, netAddr.String())
 		for k, c := range s.conns {

--- a/utp_test.go
+++ b/utp_test.go
@@ -3,6 +3,7 @@ package utp
 import (
 	"bytes"
 	"crypto/rand"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -637,5 +638,61 @@ func TestCloseNow(t *testing.T) {
 		s2.CloseNow()
 		_, err = c.Read(nil)
 		assert.Equal(t, err.Error(), "EOF")
+	}
+}
+
+// Test dial 0.0.0.0
+func Test0000ipv4(t *testing.T) {
+	testSimpleRead(t, "0.0.0.0", "0.0.0.0")
+}
+
+// Test dial [::]
+func Test0000ipv6(t *testing.T) {
+	testSimpleRead(t, "[::]", "[::]")
+}
+
+// tests a simple server accept/write/close with client dial/read.
+func testSimpleRead(t *testing.T, serverBindIP string, clientDialIP string) {
+	l, err := NewSocket("udp", fmt.Sprintf("%s:0", serverBindIP))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sport := l.pc.(*net.UDPConn).LocalAddr().(*net.UDPAddr).Port
+
+	defer func() {
+		err = l.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	serr := make(chan error, 1)
+	go func() {
+		con, err := l.Accept()
+		if err != nil {
+			serr <- err
+			return
+		}
+		io.WriteString(con, "hello")
+		serr <- con.Close()
+	}()
+
+	client, err := Dial(fmt.Sprintf("%s:%d", clientDialIP, sport))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	response, err := ioutil.ReadAll(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(response) != "hello" {
+		t.Fatalf("unexpected response %s", response)
+	}
+
+	err = client.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Use actual address used, instead of address passed by caller.  This
means we can dialling 0.0.0.0 and it will work, similar to how TCP would
work.